### PR TITLE
Ops/add quality gates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/code
+    docker:
+      - image: circleci/android:api-29
+    environment:
+      JVM_OPTS: -Xmx3200m
+    steps:
+      - checkout
+      - restore_cache:
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+      #      - run:
+      #         name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
+      #         command: sudo chmod +x ./gradlew
+      - run:
+          name: Download Dependencies
+          command: ./gradlew androidDependencies
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+      - run:
+          name: Run Tests
+          command: ./gradlew lint test
+      - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/ 
+          path: app/build/reports
+          destination: reports
+      - store_test_results: # for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+          path: app/build/test-results
+      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples

--- a/README.md
+++ b/README.md
@@ -42,5 +42,6 @@ TBD - this will be responsible for improving upon LiveData for Android.
 This is a breakdown of the different technologies that are used within
 this project.
 
-* `detekt` is used for static analysis with Kotlin. You can run this
-locally by running `./gradlew detekt`.
+* [detekt](https://github.com/arturbosch/detekt) is used for static 
+analysis with Kotlin. You can run this locally by running 
+`./gradlew detekt`.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ this project.
 * [detekt](https://github.com/arturbosch/detekt) is used for static 
 analysis with Kotlin. You can run this locally by running 
 `./gradlew detekt`.
+* [jacoco](https://www.jacoco.org/jacoco/) is used for code coverage
+reporting. You can run this locally by running `./gradlew :<MODULE>:jacocoTestReport`.

--- a/README.md
+++ b/README.md
@@ -36,3 +36,11 @@ TBD - this will be responsible for improving upon RxJava.
 ### LiveData
 
 TBD - this will be responsible for improving upon LiveData for Android.
+
+## Technologies
+
+This is a breakdown of the different technologies that are used within
+this project.
+
+* `detekt` is used for static analysis with Kotlin. You can run this
+locally by running `./gradlew detekt`.

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-buildscript { 
-    ext.kotlin_version = '1.3.50'
-
+buildscript {
     ext.versions = [
             'appcompat': '1.1.0',
             'assertk': '0.20',
+            'detekt': '1.2.1',
             'junit': '4.12',
-            'kotlin': '1.3.50',
+            'kotlin': '1.3.61',
             'mockk': '1.9'
     ]
 
@@ -20,6 +19,7 @@ buildscript {
     ]
 
     repositories {
+        maven { url "https://plugins.gradle.org/m2/" }
         google()
         jcenter()
 
@@ -28,6 +28,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${versions.detekt}"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -35,10 +36,12 @@ buildscript {
 
 allprojects {
     repositories {
+        maven { url "https://plugins.gradle.org/m2/" }
         google()
         jcenter()
-
     }
+
+    apply from: "$rootDir/detekt.gradle"
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
             'detekt': '1.2.1',
             'junit': '4.12',
             'kotlin': '1.3.61',
+            'mockito': '3.2.0',
             'mockk': '1.9'
     ]
 
@@ -15,6 +16,7 @@ buildscript {
             'assertk': "com.willowtreeapps.assertk:assertk-jvm:${versions.assertk}",
             'kotlinStdlibJdk7': "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}",
             'junit': "junit:junit:${versions.junit}",
+            'mockito': "org.mockito:mockito-core:${versions.mockito}",
             'mockk': "io.mockk:mockk:${versions.mockk}"
     ]
 
@@ -42,6 +44,7 @@ allprojects {
     }
 
     apply from: "$rootDir/detekt.gradle"
+    apply from: "$rootDir/jacoco.gradle"
 }
 
 task clean(type: Delete) {

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,564 @@
+build:
+  maxIssues: 0
+  weights:
+
+config:
+  validation: true
+  # when writing own rules with new properties, exclude the property path e.g.: "my_rule_set,.*>.*>[my_property]"
+  excludes: ""
+
+processors:
+  active: true
+  exclude:
+
+console-reports:
+  active: true
+  exclude:
+
+comments:
+  active: true
+  excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+  CommentOverPrivateFunction:
+    active: false
+  CommentOverPrivateProperty:
+    active: false
+  EndOfSentenceFormat:
+    active: true
+    endOfSentenceFormat: ([.?!][ \t\n\r\f<])|([.?!:]$)
+  UndocumentedPublicClass:
+    active: true
+    searchInNestedClass: true
+    searchInInnerClass: true
+    searchInInnerObject: true
+    searchInInnerInterface: true
+  UndocumentedPublicFunction:
+    active: true
+  UndocumentedPublicProperty:
+    active: true
+
+complexity:
+  active: true
+  ComplexCondition:
+    active: true
+    threshold: 4
+  ComplexInterface:
+    active: true
+    threshold: 10
+    includeStaticDeclarations: false
+  ComplexMethod:
+    active: true
+    threshold: 15
+    ignoreSingleWhenExpression: false
+    ignoreSimpleWhenEntries: false
+    ignoreNestingFunctions: false
+    nestingFunctions: run,let,apply,with,also,use,forEach,isNotNull,ifNull
+  LabeledExpression:
+    active: false
+    ignoredLabels: ""
+  LargeClass:
+    active: true
+    threshold: 600
+  LongMethod:
+    active: true
+    threshold: 60
+  LongParameterList:
+    active: true
+    threshold: 6
+    ignoreDefaultParameters: false
+  MethodOverloading:
+    active: false
+    threshold: 6
+  NestedBlockDepth:
+    active: true
+    threshold: 4
+  StringLiteralDuplication:
+    active: false
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    threshold: 3
+    ignoreAnnotation: true
+    excludeStringsWithLessThan5Characters: true
+    ignoreStringsRegex: '$^'
+  TooManyFunctions:
+    active: true
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    thresholdInFiles: 11
+    thresholdInClasses: 11
+    thresholdInInterfaces: 11
+    thresholdInObjects: 11
+    thresholdInEnums: 11
+    ignoreDeprecated: false
+    ignorePrivate: false
+    ignoreOverridden: false
+
+empty-blocks:
+  active: true
+  EmptyCatchBlock:
+    active: true
+    allowedExceptionNameRegex: "^(_|(ignore|expected).*)"
+  EmptyClassBlock:
+    active: true
+  EmptyDefaultConstructor:
+    active: true
+  EmptyDoWhileBlock:
+    active: true
+  EmptyElseBlock:
+    active: true
+  EmptyFinallyBlock:
+    active: true
+  EmptyForBlock:
+    active: true
+  EmptyFunctionBlock:
+    active: true
+    ignoreOverriddenFunctions: false
+  EmptyIfBlock:
+    active: true
+  EmptyInitBlock:
+    active: true
+  EmptyKtFile:
+    active: true
+  EmptySecondaryConstructor:
+    active: true
+  EmptyWhenBlock:
+    active: true
+  EmptyWhileBlock:
+    active: true
+
+exceptions:
+  active: true
+  ExceptionRaisedInUnexpectedLocation:
+    active: false
+    methodNames: 'toString,hashCode,equals,finalize'
+  InstanceOfCheckForException:
+    active: false
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+  NotImplementedDeclaration:
+    active: false
+  PrintStackTrace:
+    active: false
+  RethrowCaughtException:
+    active: false
+  ReturnFromFinally:
+    active: false
+    ignoreLabeled: false
+  SwallowedException:
+    active: false
+    ignoredExceptionTypes: 'InterruptedException,NumberFormatException,ParseException,MalformedURLException'
+    allowedExceptionNameRegex: "^(_|(ignore|expected).*)"
+  ThrowingExceptionFromFinally:
+    active: false
+  ThrowingExceptionInMain:
+    active: false
+  ThrowingExceptionsWithoutMessageOrCause:
+    active: false
+    exceptions: 'IllegalArgumentException,IllegalStateException,IOException'
+  ThrowingNewInstanceOfSameException:
+    active: false
+  TooGenericExceptionCaught:
+    active: true
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    exceptionNames:
+     - ArrayIndexOutOfBoundsException
+     - Error
+     - Exception
+     - IllegalMonitorStateException
+     - NullPointerException
+     - IndexOutOfBoundsException
+     - RuntimeException
+     - Throwable
+    allowedExceptionNameRegex: "^(_|(ignore|expected).*)"
+  TooGenericExceptionThrown:
+    active: true
+    exceptionNames:
+     - Error
+     - Exception
+     - Throwable
+     - RuntimeException
+
+formatting:
+  active: true
+  android: false
+  autoCorrect: true
+  AnnotationOnSeparateLine:
+    active: false
+    autoCorrect: true
+  ChainWrapping:
+    active: true
+    autoCorrect: true
+  CommentSpacing:
+    active: true
+    autoCorrect: true
+  Filename:
+    active: true
+  FinalNewline:
+    active: true
+    autoCorrect: true
+  ImportOrdering:
+    active: false
+    autoCorrect: true
+  Indentation:
+    active: true
+    autoCorrect: true
+    indentSize: 4
+    continuationIndentSize: 4
+  MaximumLineLength:
+    active: true
+    maxLineLength: 120
+  ModifierOrdering:
+    active: true
+    autoCorrect: true
+  MultiLineIfElse:
+    active: true
+    autoCorrect: true
+  NoBlankLineBeforeRbrace:
+    active: true
+    autoCorrect: true
+  NoConsecutiveBlankLines:
+    active: true
+    autoCorrect: true
+  NoEmptyClassBody:
+    active: true
+    autoCorrect: true
+  NoLineBreakAfterElse:
+    active: true
+    autoCorrect: true
+  NoLineBreakBeforeAssignment:
+    active: true
+    autoCorrect: true
+  NoMultipleSpaces:
+    active: true
+    autoCorrect: true
+  NoSemicolons:
+    active: true
+    autoCorrect: true
+  NoTrailingSpaces:
+    active: true
+    autoCorrect: true
+  NoUnitReturn:
+    active: true
+    autoCorrect: true
+  NoUnusedImports:
+    active: true
+    autoCorrect: true
+  NoWildcardImports:
+    active: true
+  PackageName:
+    active: true
+    autoCorrect: true
+  ParameterListWrapping:
+    active: true
+    autoCorrect: true
+    indentSize: 4
+  SpacingAroundColon:
+    active: true
+    autoCorrect: true
+  SpacingAroundComma:
+    active: true
+    autoCorrect: true
+  SpacingAroundCurly:
+    active: true
+    autoCorrect: true
+  SpacingAroundDot:
+    active: true
+    autoCorrect: true
+  SpacingAroundKeyword:
+    active: true
+    autoCorrect: true
+  SpacingAroundOperators:
+    active: true
+    autoCorrect: true
+  SpacingAroundParens:
+    active: true
+    autoCorrect: true
+  SpacingAroundRangeOperator:
+    active: true
+    autoCorrect: true
+  StringTemplate:
+    active: true
+    autoCorrect: true
+
+naming:
+  active: true
+  ClassNaming:
+    active: true
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    classPattern: '[A-Z$][a-zA-Z0-9$]*'
+  ConstructorParameterNaming:
+    active: true
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    privateParameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreOverridden: true
+  EnumNaming:
+    active: true
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    enumEntryPattern: '^[A-Z][_a-zA-Z0-9]*'
+  ForbiddenClassName:
+    active: false
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    forbiddenName: ''
+  FunctionMaxLength:
+    active: false
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    maximumFunctionNameLength: 30
+  FunctionMinLength:
+    active: false
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    minimumFunctionNameLength: 3
+  FunctionNaming:
+    active: true
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
+    excludeClassPattern: '$^'
+    ignoreOverridden: true
+  FunctionParameterNaming:
+    active: true
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreOverriddenFunctions: true
+  InvalidPackageDeclaration:
+    active: false
+    rootPackage: ''
+  MatchingDeclarationName:
+    active: true
+  MemberNameEqualsClassName:
+    active: true
+    ignoreOverriddenFunction: true
+  ObjectPropertyNaming:
+    active: true
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    constantPattern: '[A-Za-z][_A-Za-z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
+  PackageNaming:
+    active: true
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    packagePattern: '^[a-z]+(\.[a-z][A-Za-z0-9]*)*$'
+  TopLevelPropertyNaming:
+    active: true
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    constantPattern: '[A-Z][_A-Z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
+  VariableMaxLength:
+    active: false
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    maximumVariableNameLength: 64
+  VariableMinLength:
+    active: false
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    minimumVariableNameLength: 1
+  VariableNaming:
+    active: true
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    variablePattern: '[a-z][A-Za-z0-9]*'
+    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreOverridden: true
+
+performance:
+  active: true
+  ArrayPrimitive:
+    active: true
+  ForEachOnRange:
+    active: true
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+  SpreadOperator:
+    active: true
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+  UnnecessaryTemporaryInstantiation:
+    active: true
+
+potential-bugs:
+  active: true
+  Deprecation:
+    active: true
+  DuplicateCaseInWhenExpression:
+    active: true
+  EqualsAlwaysReturnsTrueOrFalse:
+    active: true
+  EqualsWithHashCodeExist:
+    active: true
+  ExplicitGarbageCollectionCall:
+    active: true
+  HasPlatformType:
+    active: false
+  ImplicitDefaultLocale:
+    active: false
+  InvalidRange:
+    active: true
+  IteratorHasNextCallsNextMethod:
+    active: true
+  IteratorNotThrowingNoSuchElementException:
+    active: true
+  LateinitUsage:
+    active: false
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludeAnnotatedProperties: ""
+    ignoreOnClassesPattern: ""
+  MissingWhenCase:
+    active: true
+  RedundantElseInWhen:
+    active: true
+  UnconditionalJumpStatementInLoop:
+    active: false
+  UnreachableCode:
+    active: true
+  UnsafeCallOnNullableType:
+    active: true
+  UnsafeCast:
+    active: false
+  UselessPostfixExpression:
+    active: false
+  WrongEqualsTypeParameter:
+    active: true
+
+style:
+  active: true
+  CollapsibleIfStatements:
+    active: false
+  DataClassContainsFunctions:
+    active: false
+    conversionFunctionPrefix: 'to'
+  DataClassShouldBeImmutable:
+    active: false
+  EqualsNullCall:
+    active: true
+  EqualsOnSignatureLine:
+    active: false
+  ExplicitItLambdaParameter:
+    active: false
+  ExpressionBodySyntax:
+    active: false
+    includeLineWrapping: false
+  ForbiddenComment:
+    active: true
+    values: 'TODO:,FIXME:,STOPSHIP:'
+    allowedPatterns: ""
+  ForbiddenImport:
+    active: false
+    imports: ''
+    forbiddenPatterns: ""
+  ForbiddenVoid:
+    active: false
+    ignoreOverridden: false
+    ignoreUsageInGenerics: false
+  FunctionOnlyReturningConstant:
+    active: true
+    ignoreOverridableFunction: true
+    excludedFunctions: 'describeContents'
+    excludeAnnotatedFunction: "dagger.Provides"
+  LibraryCodeMustSpecifyReturnType:
+    active: true
+  LoopWithTooManyJumpStatements:
+    active: true
+    maxJumpCount: 1
+  MagicNumber:
+    active: true
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    ignoreNumbers: '-1,0,1,2'
+    ignoreHashCodeFunction: true
+    ignorePropertyDeclaration: false
+    ignoreLocalVariableDeclaration: false
+    ignoreConstantDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+    ignoreAnnotation: false
+    ignoreNamedArgument: true
+    ignoreEnums: false
+    ignoreRanges: false
+  MandatoryBracesIfStatements:
+    active: true
+  MaxLineLength:
+    active: true
+    maxLineLength: 120
+    excludePackageStatements: true
+    excludeImportStatements: true
+    excludeCommentStatements: false
+  MayBeConst:
+    active: true
+  ModifierOrder:
+    active: true
+  NestedClassesVisibility:
+    active: false
+  NewLineAtEndOfFile:
+    active: false
+  NoTabs:
+    active: false
+  OptionalAbstractKeyword:
+    active: true
+  OptionalUnit:
+    active: false
+  OptionalWhenBraces:
+    active: false
+  PreferToOverPairSyntax:
+    active: false
+  ProtectedMemberInFinalClass:
+    active: true
+  RedundantExplicitType:
+    active: false
+  RedundantVisibilityModifierRule:
+    active: false
+  ReturnCount:
+    active: true
+    max: 2
+    excludedFunctions: "equals"
+    excludeLabeled: false
+    excludeReturnFromLambda: true
+    excludeGuardClauses: false
+  SafeCast:
+    active: true
+  SerialVersionUIDInSerializableClass:
+    active: false
+  SpacingBetweenPackageAndImports:
+    active: false
+  ThrowsCount:
+    active: true
+    max: 2
+  TrailingWhitespace:
+    active: false
+  UnderscoresInNumericLiterals:
+    active: false
+    acceptableDecimalLength: 5
+  UnnecessaryAbstractClass:
+    active: true
+    excludeAnnotatedClasses: "dagger.Module"
+  UnnecessaryApply:
+    active: false
+  UnnecessaryInheritance:
+    active: true
+  UnnecessaryLet:
+    active: false
+  UnnecessaryParentheses:
+    active: false
+  UntilInsteadOfRangeTo:
+    active: false
+  UnusedImports:
+    active: false
+  UnusedPrivateClass:
+    active: true
+  UnusedPrivateMember:
+    active: false
+    allowedNames: "(_|ignored|expected|serialVersionUID)"
+  UseArrayLiteralsInAnnotations:
+    active: false
+  UseCheckOrError:
+    active: false
+  UseDataClass:
+    active: false
+    excludeAnnotatedClasses: ""
+    allowVars: false
+  UseIfInsteadOfWhen:
+    active: false
+  UseRequire:
+    active: false
+  UselessCallOnNotNull:
+    active: true
+  UtilityClassWithPublicConstructor:
+    active: true
+  VarCouldBeVal:
+    active: false
+  WildcardImport:
+    active: true
+    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludeImports: 'java.util.*,kotlinx.android.synthetic.*'

--- a/core-test/src/test/java/dev/engel/projectoxygen/core/test/resources/StringProviderFakeTest.kt
+++ b/core-test/src/test/java/dev/engel/projectoxygen/core/test/resources/StringProviderFakeTest.kt
@@ -35,6 +35,27 @@ class StringProviderFakeTest {
     }
 
     @Test
+    fun `given a string does not exist for resource id, when resource id is provided with arguments, then an exception should be thrown`() {
+        assertThat {
+            subject.get(resourceId, "hey", 23)
+        }.isFailure().isInstanceOf(Throwable::class.java)
+    }
+
+    @Test
+    fun `given a string does not exist for resource id, when resource id is provided with arguments, then the correct exception should be thrown`() {
+        assertThat {
+            subject.get(resourceId, "hey", 23)
+        }.isFailure().isInstanceOf(StringResValueNotFoundException::class.java)
+    }
+
+    @Test
+    fun `given a string does not exist for resource id, when resource id is provided with arguments, then the correct cause should be provided`() {
+        assertThat {
+            subject.get(resourceId, "hey", 23)
+        }.isFailure().hasMessage(FORMATTED_MESSAGE.format(resourceId))
+    }
+
+    @Test
     fun `given a string exists for a resource id, when resource id is provided, then the string should be returned`() {
         subject.expect(stringResValue)
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,6 +23,14 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 dependencies {
@@ -32,5 +40,5 @@ dependencies {
 
     testImplementation deps.assertk
     testImplementation deps.junit
-    testImplementation deps.mockk
+    testImplementation deps.mockito
 }

--- a/core/src/main/java/dev/engel/projectoxygen/core/resources/StringProvider.kt
+++ b/core/src/main/java/dev/engel/projectoxygen/core/resources/StringProvider.kt
@@ -26,7 +26,7 @@ interface StringProvider {
     fun get(@StringRes resourceId: Int, vararg formatArguments: Any): String
 
     /**
-     * This is a convenience
+     * This is a convenience function which proxies to the vararg version of this function.
      *
      * @param resourceId - the corresponding resource id for the expected string.
      * @param formatArguments - the arguments which should be used to format the string.
@@ -52,10 +52,12 @@ interface StringProvider {
                 }
 
                 override fun get(resourceId: Int, vararg formatArguments: Any): String {
+                    @Suppress("SpreadOperator")
                     return applicationContext.getString(resourceId, *formatArguments)
                 }
 
                 override fun get(resourceId: Int, formatArguments: List<Any>): String {
+                    @Suppress("SpreadOperator")
                     return get(resourceId, *formatArguments.toTypedArray())
                 }
 

--- a/core/src/test/java/dev/engel/projectoxygen/core/resources/StringProviderTest.kt
+++ b/core/src/test/java/dev/engel/projectoxygen/core/resources/StringProviderTest.kt
@@ -1,23 +1,28 @@
 package dev.engel.projectoxygen.core.resources
 
-import android.content.Context
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import io.mockk.every
-import io.mockk.mockk
+import dev.engel.projectoxygen.core.resources.testcommons.every
+import dev.engel.projectoxygen.core.resources.testcommons.mockContext
+import dev.engel.projectoxygen.core.resources.testcommons.returns
+import dev.engel.projectoxygen.core.resources.testcommons.whenever
+import org.junit.Before
 import org.junit.Test
 
 class StringProviderTest {
+    private val context = mockContext()
 
-    private val context: Context = mockk<Context>().also { mockedContext ->
-        every { mockedContext.applicationContext } returns mockedContext
-    }
-
-    private val subject: StringProvider = StringProvider(context)
+    private lateinit var subject: StringProvider
 
     private val resourceId = 1
     private val formatArguments = listOf("hey", 51, 'n', 3.14)
     private val expectedString = "this is the expected string"
+
+    @Before
+    fun setUp() {
+        whenever(context.applicationContext).thenReturn(context)
+        subject = StringProvider(context)
+    }
 
     @Test
     fun `given a string exists for a resource id, when resource id is provided, then the string should be returned`() {

--- a/core/src/test/java/dev/engel/projectoxygen/core/resources/testcommons/AndroidMocks.kt
+++ b/core/src/test/java/dev/engel/projectoxygen/core/resources/testcommons/AndroidMocks.kt
@@ -1,0 +1,9 @@
+package dev.engel.projectoxygen.core.resources.testcommons
+
+import android.content.Context
+import org.mockito.Mockito.mock
+
+/**
+ * @return a [mock] version of an Android [Context].
+ */
+fun mockContext(): Context = mock(Context::class.java)

--- a/core/src/test/java/dev/engel/projectoxygen/core/resources/testcommons/Mockito.kt
+++ b/core/src/test/java/dev/engel/projectoxygen/core/resources/testcommons/Mockito.kt
@@ -1,0 +1,27 @@
+package dev.engel.projectoxygen.core.resources.testcommons
+
+import org.mockito.Mockito.`when`
+import org.mockito.stubbing.OngoingStubbing
+
+/**
+ * Proxies to Mockito's when function since the when keyword is reserved with Kotlin.
+ */
+fun <T> whenever(methodCall: T): OngoingStubbing<T> {
+    return `when`(methodCall)
+}
+
+/**
+ * Proxies to [whenever] in order to provide a more concise option for starting a mock chain. This
+ * is intended to replicate MockK's every function.
+ */
+fun <T> every(methodCall: () -> T): OngoingStubbing<T> {
+    return whenever(methodCall())
+}
+
+/**
+ * Proxies to Mockito's thenReturn function while adding the infix keyword allowing for cleaner
+ * definitions for mocks. This is intended to replicate MockK's returns function.
+ */
+infix fun <T> OngoingStubbing<T>.returns(returnValue: T) {
+    thenReturn(returnValue)
+}

--- a/detekt.gradle
+++ b/detekt.gradle
@@ -1,0 +1,11 @@
+apply plugin: "io.gitlab.arturbosch.detekt"
+
+detekt {
+    input = files("src/main/java")
+    config = files("../config/detekt/detekt.yml")
+    reports {
+        xml.enabled = true
+        html.enabled = true
+        txt.enabled = true
+    }
+}

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -1,0 +1,44 @@
+apply plugin: 'jacoco'
+
+ext {
+    coverageSourceDirs = 'src/test/java'
+}
+
+jacoco {
+    toolVersion = "0.8.5"
+    reportsDir = file("$buildDir/reports")
+}
+
+task jacocoTestReport(type: JacocoReport, dependsOn: "testDebugUnitTest") {
+    group = "Reporting"
+    description = "Generate Jacoco coverage reports for Debug build"
+
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+
+    def excludes = ['**/R.class',
+                    '**/R$*.class',
+                    '**/*$ViewBinder*.*',
+                    '**/*$InjectAdapter*.*',
+                    '**/*Injector*.*',
+                    '**/BuildConfig.*',
+                    '**/Manifest*.*',
+                    '**/*Test*.*',
+                    '**/*Activity*.*',
+                    '**/CiMattersApplication*.*',
+                    'android/**/*.*']
+
+    def debugTree = fileTree(
+            dir: "$buildDir/intermediates/javac/debug/compileDebugJavaWithJavac/classes/de/logerbyte/jacocotest",
+            excludes: excludes)
+    def kotlinDebugTree = fileTree(
+            dir: "$buildDir/tmp/kotlin-classes/debug",
+            excludes: excludes)
+    def mainSrc = "${project.projectDir}/src/main/java"
+
+    classDirectories = files([debugTree], [kotlinDebugTree])
+    executionData = files("$buildDir/jacoco/testDebugUnitTest.exec")
+    sourceDirectories = files([mainSrc])
+}


### PR DESCRIPTION
* Added Detekt to the project.
* Configured the project rules via detekt.yml.
* Updated StringProvider which wasn't passing the detekt check.
* Added Jacoco to the project to check for code coverage within the project's modules.
* Updated StringProviderFakeTest to include some missing test cases which were picked up by Jacoco.
* Added Mockito to the project as MockK was not able to mock the Android Context while running via terminal, this seems odd and worth revisiting in the future.
* Added some convenience functions for mocking the Android Context as well as functions which share the same name/functionality as MockK, just for Mockito.
* Added the default CircleCI configuration as a baseline to start from.